### PR TITLE
Fixed .env file creation in npm init script

### DIFF
--- a/bin/init.js
+++ b/bin/init.js
@@ -101,13 +101,13 @@ try{
         COMMENCER_SESSION_COOKIE_KEY:"your_session_cookie_key",
         COMMENCER_USER_JWT_NAME:"your_user_jwt_name",
         COMMENCER_USER_JWT_KEY:"your_user_jwt_key",
-        COMMENCER_ENVIRONMENT : "DEVELOPMENT  #acceptable values = {DEVELOPMENT, PRODUCTION, TESTING}" ,
+        COMMENCER_ENVIRONMENT : "DEVELOPMENT"  #acceptable values = {DEVELOPMENT, PRODUCTION, TESTING} ,
         APP_NAME : "your-app-name",
         MAIL_CLIENT_ID: "your-mail-client-id",
         MAIL_CLIENT_SECRET: "your-mail-client-secret",
         MAIL_REDIRECT_URI: "your-mail-redirect-uri",
         MAIL_REFRESH_TOKEN:"your-mail-refresh-token",
-        MAIL_SERVICE: "your-mail-service #currently gmail is supported, for other services, kindly look forward to updated versions, if you can help with this, kindly contribute to our github repository",
+        MAIL_SERVICE: "your-mail-service" #currently gmail is supported, for other services, kindly look forward to updated versions, if you can help with this, kindly contribute to our github repository,
         SENDER_MAIL:"your-sender-mail",
     }
     


### PR DESCRIPTION
Fixed .env file creation in npm init script 

COMMENCER_ENVIRONMENT and SENDER_MAIL variables were having comments included in the value string

Resolved by separating comments out of the value string

Issue Reference: #<issue-number>