### PR TITLE
Test cases for logout api and fixed http status code for isValidSession Middleware

### DIFF
--- a/src/middlewares/session/isValidSession.ts
+++ b/src/middlewares/session/isValidSession.ts
@@ -11,7 +11,7 @@ export default function isValidSession(req:Request,res:Response,next:NextFunctio
         const sessionJwtToken:string|undefined = Array.isArray(sessionJwtHeaders) ? sessionJwtHeaders[0] : sessionJwtHeaders
         const sessionIDFromSessionCookie = req.signedCookies[SessionCookie.name]
         if(sessionJwtToken === undefined || isEmptyStr(sessionJwtToken) || isEmptyStr(sessionIDFromSessionCookie)){
-            throw new Error("Session credentials not found")
+            res.status(401).json({message:"Session credentials not found",fetched:false})
         }
         else{
             const jwtTokenData = jwt.verify(sessionJwtToken,SessionJwt.key) as SessionJwtPayload

--- a/src/tests/auth/auth.logout.test.ts
+++ b/src/tests/auth/auth.logout.test.ts
@@ -1,0 +1,95 @@
+import request, { Response } from "supertest"
+import app from "../../app"
+import { describe } from "node:test"
+import { SessionJwt } from "../../config/jwt"
+import { generateSessionJwt } from "../../utils/jwt"
+import { v4 } from "uuid"
+import { SessionCookie } from "../../config/cookie"
+import { sign } from "cookie-signature"
+
+describe("logout api tests", ()=>{
+
+    describe("valid session jwt is provided and session cookie is present",()=>{
+        let response:Response
+        beforeAll(async ()=>{
+            const sessionId = v4()
+            response = await request(app)
+                .post("/auth/logout")
+                .set(SessionJwt.name,generateSessionJwt(sessionId,SessionJwt.key))
+                .set('Cookie',`${SessionCookie.name}=s:${sign(sessionId,SessionCookie.key)}`)
+        })
+        test("should respond with a status 200 code", async ()=>{
+            expect(response.status).toBe(200)
+        })
+        test("should respond with a json object containing message", async ()=>{
+            expect(response.headers['content-type']).toEqual(expect.stringContaining("json"))
+            expect(response.body).toHaveProperty("fetched")
+            expect(response.body.fetched).toBe(true)
+            expect(response.body).toHaveProperty("message")
+            expect(response.body.message).toBeDefined()
+        })
+    })
+
+    describe("either session cookie or session jwt is absent, due to expiry or previous logout",()=>{
+        let response:Response
+        const sessionId = v4()
+        const testCases = [
+            {
+                Cookie:`${SessionCookie.name}=s:${sign(sessionId,v4())}`,
+            },
+            {
+                [SessionJwt.name]:generateSessionJwt(sessionId,SessionJwt.key)
+            },
+        ]
+        testCases.forEach(testCase=>{
+            let req = request(app)
+                .post("/auth/logout")
+            Object.keys(testCase).forEach(key=>{
+                req.set(key,testCase[key])
+            })
+            beforeAll(async ()=>{
+                response = await req
+            })
+            test("should respond with a status 401 code", async ()=>{
+                expect(response.status).toBe(401)
+            })
+            test("should respond with a json object containing message", async ()=>{
+                expect(response.headers['content-type']).toEqual(expect.stringContaining("json"))
+                expect(response.body).toHaveProperty("fetched")
+                expect(response.body.fetched).toBe(false)
+                expect(response.body).toHaveProperty("message")
+                expect(response.body.message).toBeDefined()
+            })
+        })
+    })
+
+    describe("mismatch of session ID between cookie and jwt",()=>{
+        let response:Response
+        const testCases = [
+            {
+                Cookie:`${SessionCookie.name}=s:${sign(v4(),SessionCookie.key)}`,
+                [SessionJwt.name]:generateSessionJwt(v4(),SessionJwt.key)
+            },
+        ]
+        testCases.forEach(testCase=>{
+            let req = request(app)
+                .post("/auth/logout")
+            Object.keys(testCase).forEach(key=>{
+                req.set(key,testCase[key])
+            })
+            beforeAll(async ()=>{
+                response = await req
+            })
+            test("should respond with a status 403 code", async ()=>{
+                expect(response.status).toBe(403)
+            })
+            test("should respond with a json object containing message", async ()=>{
+                expect(response.headers['content-type']).toEqual(expect.stringContaining("json"))
+                expect(response.body).toHaveProperty("fetched")
+                expect(response.body.fetched).toBe(false)
+                expect(response.body).toHaveProperty("message")
+                expect(response.body.message).toBeDefined()
+            })
+        })
+    })
+})


### PR DESCRIPTION
- Required To publish the logout api after adding tests.

Closes Issue Ref #14 

- Created a new file for writing tests for logout api
- Created the following tests
  - Logout from session when valid session jwt and cookie are present
  - Logout failure for absent/missing session jwt/cookie
  - Logout failure for invalid session jwt/cookie.