### PR TITLE
feat: add OTP email templates for registration, resend, and forgot password

### DIFF
--- a/src/assets/forgot_password_otp.hbs
+++ b/src/assets/forgot_password_otp.hbs
@@ -1,0 +1,27 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      body { font-family: Arial, sans-serif; background-color: #f4f4f9; padding:
+      20px; margin: 0; } .container { max-width: 600px; margin: 0 auto;
+      background-color: #ffffff; padding: 20px; border-radius: 10px; box-shadow:
+      0 2px 10px rgba(0, 0, 0, 0.1); } .header { text-align: center; color:
+      #F44336; margin-bottom: 20px; } .message { font-size: 16px; color:
+      #333333; } .otp { font-size: 24px; font-weight: bold; background-color:
+      #FFEBEE; color: #D32F2F; padding: 10px; border-radius: 5px; text-align:
+      center; margin: 20px 0; } .footer { text-align: center; color: #999999;
+      font-size: 12px; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1 class="header">Reset Your Password, {{name}}</h1>
+      <p class="message">You requested to reset your password. Please use the
+        following OTP to proceed:</p>
+      <div class="otp">{{otp}}</div>
+      <p class="footer">If you did not request a password reset, please contact
+        our support team immediately.</p>
+    </div>
+  </body>
+</html>

--- a/src/assets/registration_otp.hbs
+++ b/src/assets/registration_otp.hbs
@@ -1,0 +1,27 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      body { font-family: Arial, sans-serif; background-color: #f4f4f9; padding:
+      20px; margin: 0; } .container { max-width: 600px; margin: 0 auto;
+      background-color: #ffffff; padding: 20px; border-radius: 10px; box-shadow:
+      0 2px 10px rgba(0, 0, 0, 0.1); } .header { text-align: center; color:
+      #4CAF50; margin-bottom: 20px; } .message { font-size: 16px; color:
+      #333333; } .otp { font-size: 24px; font-weight: bold; background-color:
+      #e8f5e9; color: #2e7d32; padding: 10px; border-radius: 5px; text-align:
+      center; margin: 20px 0; } .footer { text-align: center; color: #999999;
+      font-size: 12px; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1 class="header">Welcome to Our Service, {{name}}!</h1>
+      <p class="message">Thank you for registering. Please use the following OTP
+        to complete your registration:</p>
+      <div class="otp">{{otp}}</div>
+      <p class="footer">If you did not initiate this request, please contact our
+        support team immediately.</p>
+    </div>
+  </body>
+</html>

--- a/src/assets/resend_otp.hbs
+++ b/src/assets/resend_otp.hbs
@@ -1,0 +1,27 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      body { font-family: Arial, sans-serif; background-color: #f4f4f9; padding:
+      20px; margin: 0; } .container { max-width: 600px; margin: 0 auto;
+      background-color: #ffffff; padding: 20px; border-radius: 10px; box-shadow:
+      0 2px 10px rgba(0, 0, 0, 0.1); } .header { text-align: center; color:
+      #FFA726; margin-bottom: 20px; } .message { font-size: 16px; color:
+      #333333; } .otp { font-size: 24px; font-weight: bold; background-color:
+      #FFF3E0; color: #F57C00; padding: 10px; border-radius: 5px; text-align:
+      center; margin: 20px 0; } .footer { text-align: center; color: #999999;
+      font-size: 12px; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1 class="header">Here's Your OTP, {{name}}!</h1>
+      <p class="message">You requested a new OTP. Please use the following OTP
+        to continue:</p>
+      <div class="otp">{{otp}}</div>
+      <p class="footer">If you did not request this OTP, please contact our
+        support team immediately.</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
### ✨ Description
This PR adds three `.hbs` templates for sending OTP emails for the following user flows:

1. 📝 **User Registration**: Sends an OTP when a user first registers.
2. 🔄 **Resend OTP**: Sends an OTP when the user requests a resend.
3. 🔐 **Forgot Password**: Sends an OTP when the user initiates the forgot password process.

### 🚀 Changes
- **HTML and CSS**: Each template includes a responsive design with clean, user-friendly styling.
  - Customized headers and messages for each template.
  - OTP displayed prominently with bold text and styled background for emphasis.
  - Placeholder fields for `name` and `OTP` to be dynamically populated.

### 🔗 Related Issues
#16 Create Email template for OTP
